### PR TITLE
fix sed @line41 to not randomly destroy inline certs

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -38,7 +38,7 @@ cert_auth() { local passwd="$1"
 #   none)
 # Return: conf file that uses VPN provider's DNS resolvers
 dns() {
-    sed -i '/down\|up/d; /resolv-*conf/d; /script-security/d' $conf
+    sed -i '/^down\ |^up\ /d; /^script-security/d' $conf
     echo "# This updates the resolvconf with dns settings" >>$conf
     echo "script-security 2" >>$conf
     echo "up /etc/openvpn/up.sh" >>$conf


### PR DESCRIPTION
<pre>
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~# docker-compose up
Starting root_vpn_1
Attaching to root_vpn_1
vpn_1  | Tue Feb 12 22:00:38 2019 WARNING: --keysize is DEPRECATED and will be removed in OpenVPN 2.6
vpn_1  | Tue Feb 12 22:00:38 2019 OpenVPN 2.4.6 x86_64-alpine-linux-musl [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [MH/PKTINFO] [AEAD] built on Nov 26 2018
vpn_1  | Tue Feb 12 22:00:38 2019 library versions: OpenSSL 1.1.1a  20 Nov 2018, LZO 2.10
vpn_1  | Tue Feb 12 22:00:38 2019 NOTE: the current --script-security setting may allow this configuration to call user-defined scripts
vpn_1  | Tue Feb 12 22:00:38 2019 OpenSSL: error:0D07209B:asn1 encoding routines:ASN1_get_object:too long
vpn_1  | Tue Feb 12 22:00:38 2019 OpenSSL: error:0D068066:asn1 encoding routines:asn1_check_tlen:bad object header
vpn_1  | Tue Feb 12 22:00:38 2019 OpenSSL: error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error
vpn_1  | Tue Feb 12 22:00:38 2019 OpenSSL: error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib
vpn_1  | Tue Feb 12 22:00:38 2019 OpenSSL: error:140AD009:SSL routines:SSL_CTX_use_certificate_file:PEM lib
vpn_1  | Tue Feb 12 22:00:38 2019 Cannot load inline certificate file
vpn_1  | Tue Feb 12 22:00:38 2019 Exiting due to fatal error
root_vpn_1 exited with code 1
root@dock:~# ^C
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
10d9
< #### Server Settings (dont change anything down here!)
31,34d29
< #--INFO-- Use update-resolv-conf to FIX DNSLEAK! See https://wiki.archlinux.org/index.php/OpenVPN#DNS for Details! Works with ALL LINUX!!
< #script-security 2
< #up /etc/openvpn/update-resolv-conf
< #down /etc/openvpn/update-resolv-conf
94d88
< 3EByoA7KYgLWyQrDTZ865/CDy/6ejoDqc2mqMUB53zq94SOoUJCUjup1oxDP0cI0
113d106
< tDsEIPlOiWRVyCxX7QupapMoFZkG8hk2ID8C1FsaA5U8DCGbJHXC5bgLPoQ3Mp9m
121d113
< upsUXC7FrxClFcQ2/xKauC4GcIcrrBCS/ysg0BdnZ4/FGmBKzBfkNALk2XcTfHh8
173a166,169
> # This updates the resolvconf with dns settings
> script-security 2
> up /etc/openvpn/up.sh
> down /etc/openvpn/down.sh
root@dock:~# docker-compose stop
root@dock:~# cp /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~# conf=vpn/bg1.conf
root@dock:~# sed -i '/down\|up/d; /resolv-*conf/d; /script-security/d' $conf
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
10d9
< #### Server Settings (dont change anything down here!)
31,34d29
< #--INFO-- Use update-resolv-conf to FIX DNSLEAK! See https://wiki.archlinux.org/index.php/OpenVPN#DNS for Details! Works with ALL LINUX!!
< #script-security 2
< #up /etc/openvpn/update-resolv-conf
< #down /etc/openvpn/update-resolv-conf
94d88
< 3EByoA7KYgLWyQrDTZ865/CDy/6ejoDqc2mqMUB53zq94SOoUJCUjup1oxDP0cI0
113d106
< tDsEIPlOiWRVyCxX7QupapMoFZkG8hk2ID8C1FsaA5U8DCGbJHXC5bgLPoQ3Mp9m
121d113
< upsUXC7FrxClFcQ2/xKauC4GcIcrrBCS/ysg0BdnZ4/FGmBKzBfkNALk2XcTfHh8
root@dock:~# cp /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~# conf=vpn/bg1.conf 
root@dock:~# sed -i '/^down\ |^up\ /d; /^script-security/d' $conf
root@dock:~# diff /home/user/Downloads/vpn/BG1.ovpn.to.ovpn vpn/bg1.conf
root@dock:~#
</pre>